### PR TITLE
35 전체화면에서 최대화로 돌아가기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mouse_gesture_for_chrome",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mouse_gesture_for_chrome",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "MIT",
       "dependencies": {
         "@material/checkbox": "^14.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1677,9 +1677,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001466",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001466.tgz",
-      "integrity": "sha512-ewtFBSfWjEmxUgNBSZItFSmVtvk9zkwkl1OfRZlKA8slltRN+/C/tuGVrF9styXkN36Yu3+SeJ1qkXxDEyNZ5w==",
+      "version": "1.0.30001600",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
       "dev": true,
       "funding": [
         {
@@ -1689,6 +1689,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mouse_gesture_for_chrome",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "[한국어 페이지](README.md)",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,21 +1,18 @@
-import { default_options } from '@common/default_options';
+import '@background/install';
+import { updateWindowSize, WindowState } from '@background/update_window';
 
 const getCurrentWindowTabs = () => chrome.tabs.query({lastFocusedWindow: true});
-const openOptions = () => chrome.runtime.openOptionsPage();
 const sendMessage = (tabId, message) => chrome.tabs.sendMessage(tabId, message);
 const moveTab = (index, wid) => getCurrentWindowTabs().then((tabs) => chrome.tabs.highlight({tabs: (tabs.length + index) % tabs.length, windowId: wid}));
-const getWindow = (wid) => chrome.windows.get(wid);
-const updateWindow = (wid, updateInfo) => chrome.windows.update(wid, updateInfo);
-const updateWindowSize = (wid, next_state) => getWindow(wid).then(({state}) => updateWindow(wid, {state: (state === next_state) ? 'normal' : next_state}));
 
 chrome.runtime.onMessage.addListener(
     (request, sender, sendResponse) => {
         const gesture = request.gesture;
         const details = request.details;
 
-        const tabId = sender.tab.id;
-        const tabIndex = sender.tab.index;
-        const windowId = sender.tab.windowId;
+        const tab_id = sender.tab.id;
+        const tab_index = sender.tab.index;
+        const window_id = sender.tab.windowId;
 
         var result_promise;
         switch(gesture) {
@@ -23,52 +20,52 @@ chrome.runtime.onMessage.addListener(
                 result_promise = chrome.sessions.restore();
                 break;
             case 'closeTab':
-                result_promise =  chrome.tabs.remove(tabId);
+                result_promise =  chrome.tabs.remove(tab_id);
                 break;
             case 'goBack':
-                result_promise = chrome.tabs.goBack(tabId).then(() => true).catch(() => false);
+                result_promise = chrome.tabs.goBack(tab_id).then(() => true).catch(() => false);
                 break;
             case 'reload':
                 result_promise = chrome.tabs.reload().then(() => true).catch(() => false);
                 break;
             case 'scrollTop':
-                result_promise = sendMessage(tabId, {action: 'scrollTop'});
+                result_promise = sendMessage(tab_id, {action: 'scrollTop'});
                 break;
             case 'scrollBottom':
-                result_promise = sendMessage(tabId, {action: 'scrollBottom'});
+                result_promise = sendMessage(tab_id, {action: 'scrollBottom'});
                 break;
             case 'pageDown':
-                result_promise = sendMessage(tabId, {action: 'pageDown'});
+                result_promise = sendMessage(tab_id, {action: 'pageDown'});
                 break;
             case 'pageUp':
-                result_promise = sendMessage(tabId, {action: 'pageUp'});
+                result_promise = sendMessage(tab_id, {action: 'pageUp'});
                 break;
             case 'keydown':
-                result_promise = sendMessage(tabId, {action: 'keydown', details: details});
+                result_promise = sendMessage(tab_id, {action: 'keydown', details: details});
                 break;
             case 'moveTabRelative':
-                result_promise = moveTab(tabIndex + details.index, windowId);
+                result_promise = moveTab(tab_index + details.index, window_id);
                 break;
             case 'moveTabAbsolute':
-                result_promise = moveTab(details.index, windowId);
+                result_promise = moveTab(details.index, window_id);
                 break;
             case 'openTab':
-                result_promise = chrome.tabs.create({...details, index: tabIndex + 1, openerTabId: tabId});
+                result_promise = chrome.tabs.create({...details, index: tab_index + 1, openerTabId: tab_id});
                 break;
             case 'openWindow':
                 result_promise = chrome.windows.create({...details});
                 break;
             case 'normalizeWindow':
-                result_promise = updateWindowSize(windowId, 'normal');
+                result_promise = updateWindowSize(window_id, WindowState.NORMAL);
                 break;
             case 'minimizeWindow':
-                result_promise = updateWindowSize(windowId, 'minimized');
+                result_promise = updateWindowSize(window_id, WindowState.MINIMIZED);
                 break;
             case 'maximizeWindow':
-                result_promise = updateWindowSize(windowId, 'maximized');
+                result_promise = updateWindowSize(window_id, WindowState.MAXIMIZED);
                 break;
             case 'fullscreenWindow':
-                result_promise = updateWindowSize(windowId, 'fullscreen');
+                result_promise = updateWindowSize(window_id, WindowState.FULLSCREEN);
                 break;
             default:
                 console.error('unknown gesture:', gesture);
@@ -78,23 +75,3 @@ chrome.runtime.onMessage.addListener(
         return true;
     }
 );
-
-chrome.runtime.onInstalled.addListener((details) => {
-    switch (details.reason) {
-        case 'install':
-            chrome.storage.sync.set(default_options);
-            openOptions();
-            break;
-        case 'update':
-            chrome.storage.sync.get().then((options) => {
-                chrome.storage.sync.set({
-                    ...default_options,
-                    ...options,
-                    'version': chrome.runtime.getManifest().version
-                });
-            });
-            break;
-        default:
-            break;
-    }
-});

--- a/src/background/install.js
+++ b/src/background/install.js
@@ -1,0 +1,23 @@
+import { default_options } from '@common/default_options';
+
+const openOptions = () => chrome.runtime.openOptionsPage();
+
+chrome.runtime.onInstalled.addListener((details) => {
+    switch (details.reason) {
+        case 'install':
+            chrome.storage.sync.set(default_options);
+            openOptions();
+            break;
+        case 'update':
+            chrome.storage.sync.get().then((options) => {
+                chrome.storage.sync.set({
+                    ...default_options,
+                    ...options,
+                    'version': chrome.runtime.getManifest().version
+                });
+            });
+            break;
+        default:
+            break;
+    }
+});

--- a/src/background/update_window.js
+++ b/src/background/update_window.js
@@ -1,0 +1,51 @@
+export const WindowState = {
+    NORMAL: 'normal',
+    MINIMIZED: 'minimized',
+    MAXIMIZED: 'maximized',
+    FULLSCREEN: 'fullscreen',
+}
+
+var window_state_cache = {};
+
+const initWindowStateCache = (wid, curr_state) => {
+    window_state_cache[wid] ??= {
+        extensionEvent: false,
+        prev: WindowState.NORMAL,
+        curr: curr_state,
+    };
+};
+
+export const updateWindowSize = (wid, state) => {
+    return chrome.windows.getCurrent().then((window) => {
+        let curr_state = window.state;
+        initWindowStateCache(wid, curr_state);
+        let next_state = (curr_state === state) ? window_state_cache[wid].prev : state;
+        if (curr_state !== next_state) {
+            window_state_cache[wid].extensionEvent = true;
+            window_state_cache[wid].prev = window_state_cache[wid].curr;
+            window_state_cache[wid].curr = next_state;
+        }
+        return chrome.windows.update(wid, {state: next_state});
+    });
+};
+
+chrome.windows.onCreated.addListener((window) => {
+    initWindowStateCache(window.id, window.state);
+});
+
+chrome.windows.onBoundsChanged.addListener((window) => {
+    let {id: wid, state} = window;
+    initWindowStateCache(wid, state);
+    if (window_state_cache[wid].extensionEvent) { // transition by extension event
+        if (window_state_cache[wid].curr === state) { // end of transitions
+            window_state_cache[wid].extensionEvent = false;
+        }
+    } else { // transition by user control
+        window_state_cache[wid].prev = window_state_cache[wid].curr;
+        window_state_cache[wid].curr = state;
+    }
+});
+
+chrome.windows.onRemoved.addListener((window_id) => {
+    delete window_state_cache[window_id];
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "마우스 제스처 크롬 확장 프로그램",
-    "version": "0.0.14",
+    "version": "0.0.15",
 
     "description": "크롬 브라우저 용 마우스 제스처 확장 프로그램",
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
   },
   resolve: {
     alias: {
+        "@background": path.resolve(__dirname, 'src/background'),
         "@common": path.resolve(__dirname, 'src/common'),
         "@content_scripts": path.resolve(__dirname, 'src/content_scripts'),
         "@options": path.resolve(__dirname, 'src/options'),


### PR DESCRIPTION
1. 가장 최근에 변경된 창 크기를 기억
2. 동일 제스처 입력 시 기존 창 크기로 변경

---

1. 백그라운드 파일 분리
2. 제스처를 사용하여 전체화면을 설정하면 F11키를 눌렀을 때 기존 크기로 돌아오지 않음
    - `chrome.window.update`를 사용하여 전체화면으로 변경하거나, 전체화면에서 나올 때 `'normal'`상태를 거쳐가서 생기는 문제
    - 크롬 브라우저의 코드를 수정해야 할 듯...