### PR TITLE
40 설정이 초기화 됨

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mouse_gesture_for_chrome",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mouse_gesture_for_chrome",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "MIT",
       "dependencies": {
         "@material/checkbox": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mouse_gesture_for_chrome",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "[한국어 페이지](README.md)",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/background/install.js
+++ b/src/background/install.js
@@ -5,9 +5,7 @@ export const openOptions = () => chrome.runtime.openOptionsPage();
 chrome.runtime.onInstalled.addListener((details) => {
     switch (details.reason) {
         case 'install':
-            chrome.storage.sync.set(default_options);
             openOptions();
-            break;
         case 'update':
             chrome.storage.sync.get().then((options) => {
                 chrome.storage.sync.set({

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "마우스 제스처 크롬 확장 프로그램",
-    "version": "0.0.16",
+    "version": "0.0.17",
 
     "description": "크롬 브라우저 용 마우스 제스처 확장 프로그램",
 


### PR DESCRIPTION
설정을 커스터마이징 한 후 새로운 기기에 로그인 할 경우, `install` 이벤트가 실행되어 기존 설정이 초기화되는 문제 발생 #40

`install` 이벤트에도 설정을 업데이트 하도록 변경